### PR TITLE
timps: bump TIMPS_VERSION to v1.8.5

### DIFF
--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.8.4
+TIMPS_VERSION = v1.8.5
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.


### PR DESCRIPTION
Fixes RTCP SR stale NTP<->RTP timestamp pairing causing ffmpeg/mpv playback jumps. See https://github.com/Lu-Fi/timps/releases/tag/v1.8.5